### PR TITLE
fix object mapper's configure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,10 @@ group = 'io.digdag.plugin'
 version = '0.1.0'
 
 def digdagVersion = '0.9.4'
+def jacksonVersion = "2.9.10"
+def jacksonDatabindVersion = "2.9.10"
+def guavaVersion = "19.0"
+
 
 repositories {
     mavenCentral()
@@ -23,9 +27,20 @@ configurations {
 }
 
 dependencies {
-    provided 'io.digdag:digdag-plugin-utils:' + digdagVersion  // this should be 'compile' once digdag 0.8.2 is released to a built-in repository
-    provided 'io.digdag:digdag-core:' + digdagVersion
-    compile files('./libs/digdag-standards-0.10.0-SNAPSHOT.jar')
+    provided ('io.digdag:digdag-plugin-utils:0.9.3') { // this should be 'compile' once digdag 0.8.2 is released to a built-in repository {
+        exclude group: 'com.google.guava', module: 'guava'
+        exclude group: 'javax.inject', module: 'javax.inject'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+    }
+    provided files('./libs/digdag-standards-0.10.0-SNAPSHOT.jar')
+
+    provided "com.google.guava:guava:19.0"
+    provided 'javax.inject:javax.inject:1'
+    provided "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+    provided "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
+    provided "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'

--- a/src/main/java/io/digdag/plugin/gke/GkePlugin.java
+++ b/src/main/java/io/digdag/plugin/gke/GkePlugin.java
@@ -26,13 +26,11 @@ public class GkePlugin implements Plugin {
         @Inject
         protected CommandExecutor exec;
         @Inject
-        protected ObjectMapper mapper;
-        @Inject
         protected ConfigFactory cf;
 
         @Override
         public List<OperatorFactory> get() {
-            return Arrays.asList(new GkeOperatorFactory(exec, cf, mapper));
+            return Arrays.asList(new GkeOperatorFactory(exec, cf));
         }
     }
 }


### PR DESCRIPTION
when use injected object mapper from task manager, we can get following issue.(When using a custom operator)
https://github.com/treasure-data/digdag/issues/1339

So to avoid the above problem, we don't use injected object mapper.
Also, ObjectMapper is used to deserialize json to Config.class, so we have some configuration in ObjectMapper.
ref. 
https://github.com/treasure-data/digdag/blob/cfc6cc23b52cc3e1d27f639662f6266ad97d7c38/digdag-client/src/main/java/io/digdag/client/DigdagClient.java#L181-L194